### PR TITLE
Added deployment example and corrected typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Vanilla CSS team maintains every byte of code in the framework and works har
 * Netflix  
 * Stack Overflow  
 
-In fact, Vanilla JS is already used on more websites than LESS, SASS, Stylus, and BEM - _combined_.  
+In fact, Vanilla CSS is already used on more websites than LESS, SASS, Stylus, and BEM - _combined_.  
   
 ### Download
 Ready to try Vanilla CSS?  Follow these simple steps
@@ -60,6 +60,18 @@ p {
 }
 ```
 ---  
+* Step 4 - Deploy
+
+Deploying Vanilla CSS in your next HTML project is as simple as placing a link element in the head of your HTML document.
+
+### Example
+```
+<head>
+<link rel="stylesheet" href="vanilla.css">
+</head>
+```
+Just save your HTML document, open it in your favorite web browser, and see the delicious results!
+
 
 ### Testimonials  
 > Native support for HTML5 and other cutting-edge technologies makes me keep coming back to Vanilla CSS, time after time.  


### PR DESCRIPTION
Added detailed deployment instructions as step 4. Also fixed typo on line 28 where `Vanilla CSS` was referenced as `Vanilla JS`.
